### PR TITLE
use c_char instead of i8

### DIFF
--- a/src/audio_encoder.rs
+++ b/src/audio_encoder.rs
@@ -62,7 +62,7 @@ impl AudioEncoder {
       let ret = avcodec_receive_packet(self.codec_context, packet.packet as *mut _);
 
       if ret == AVERROR(EAGAIN) || ret == AVERROR_EOF {
-        let mut data = [0i8; AV_ERROR_MAX_STRING_SIZE];
+        let mut data = [0; AV_ERROR_MAX_STRING_SIZE];
         av_strerror(ret, data.as_mut_ptr(), AV_ERROR_MAX_STRING_SIZE);
         trace!("{}", tools::to_string(data.as_ptr()));
         return Ok(false);

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ macro_rules! check_result {
   ($condition: expr, $block: block) => {
     let errnum = $condition;
     if errnum < 0 {
-      let mut data = [0i8; AV_ERROR_MAX_STRING_SIZE];
+      let mut data = [0; AV_ERROR_MAX_STRING_SIZE];
       av_strerror(errnum, data.as_mut_ptr(), AV_ERROR_MAX_STRING_SIZE);
       $block;
       return Err(tools::to_string(data.as_ptr()));
@@ -12,7 +12,7 @@ macro_rules! check_result {
   ($condition: expr) => {
     let errnum = $condition;
     if errnum < 0 {
-      let mut data = [0i8; AV_ERROR_MAX_STRING_SIZE];
+      let mut data = [0; AV_ERROR_MAX_STRING_SIZE];
       av_strerror(errnum, data.as_mut_ptr(), AV_ERROR_MAX_STRING_SIZE);
       return Err(tools::to_string(data.as_ptr()));
     }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,6 +1,7 @@
 use crate::tools;
 use ffmpeg_sys::AVOptionType::*;
 use ffmpeg_sys::*;
+use libc::c_char;
 use std::ffi::CString;
 use std::fmt;
 use std::ptr::null_mut;
@@ -31,7 +32,7 @@ impl Filter {
       ));
     }
 
-    let context = if instance_name == "" {
+    let context = if instance_name.is_empty() {
       avfilter_graph_alloc_filter(filter_graph, filter, null_mut())
     } else {
       let i_name = CString::new(instance_name).unwrap();
@@ -173,7 +174,7 @@ fn dump_option(
           value_ptr as *mut *mut _,
         );
 
-        tools::to_string(data as *const i8)
+        tools::to_string(data as *const c_char)
       }
       AV_OPT_TYPE_SAMPLE_FMT => {
         let format = AVSampleFormat::AV_SAMPLE_FMT_NONE;
@@ -244,7 +245,7 @@ fn dump_options(filter: *mut AVFilterContext, class: *const AVClass, f: &mut fmt
 }
 
 fn dump_link(
-  pad_name: *const i8,
+  pad_name: *const c_char,
   link: *mut AVFilterLink,
   mode: &str,
   is_input: bool,

--- a/src/order/parameters.rs
+++ b/src/order/parameters.rs
@@ -1,7 +1,7 @@
 use crate::tools;
 use crate::tools::rational::Rational;
 use ffmpeg_sys::*;
-use libc::c_void;
+use libc::{c_char, c_void};
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::hash::BuildHasher;
@@ -38,7 +38,7 @@ impl ParameterValue {
       }
       ParameterValue::String(data) => self.set_str_parameter(context, &key, &data),
       ParameterValue::ChannelLayout(data) => {
-        let mut ch_layout = [0i8; 64];
+        let mut ch_layout = [0; 64];
         unsafe {
           av_get_channel_layout_string(ch_layout.as_mut_ptr(), 64, 0, *data);
         }
@@ -47,7 +47,12 @@ impl ParameterValue {
     }
   }
 
-  fn set_parameter(&self, context: *mut c_void, key: &str, value: *const i8) -> Result<(), String> {
+  fn set_parameter(
+    &self,
+    context: *mut c_void,
+    key: &str,
+    value: *const c_char,
+  ) -> Result<(), String> {
     let key_str = CString::new(key).unwrap();
     unsafe {
       check_result!(av_opt_set(

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,4 +1,5 @@
 use ffmpeg_sys::{avcodec_find_encoder_by_name, AVCodec, AVMediaType};
+use libc::c_char;
 use rand::prelude::SliceRandom;
 use rand::thread_rng;
 use std::ffi::CStr;
@@ -19,7 +20,7 @@ pub unsafe fn from_buf_raw<T>(ptr: *const T, elts: usize) -> Vec<T> {
 static ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz";
 
 /// # Safety
-pub unsafe fn to_string(data: *const i8) -> String {
+pub unsafe fn to_string(data: *const c_char) -> String {
   if data.is_null() {
     return "".to_string();
   }

--- a/src/video_encoder.rs
+++ b/src/video_encoder.rs
@@ -129,7 +129,7 @@ impl VideoEncoder {
       let ret = avcodec_receive_packet(self.codec_context, packet.packet as *mut _);
 
       if ret == AVERROR(EAGAIN) || ret == AVERROR_EOF {
-        let mut data = [0i8; AV_ERROR_MAX_STRING_SIZE];
+        let mut data = [0; AV_ERROR_MAX_STRING_SIZE];
         av_strerror(ret, data.as_mut_ptr(), AV_ERROR_MAX_STRING_SIZE);
         trace!("{}", tools::to_string(data.as_ptr()));
         return Ok(false);


### PR DESCRIPTION
Thank you for making this great crate. I believe it is the best Rust wrapper for FFmpeg. It works perfectly on x86, but cannot be built on ARM, because `c_char` is unsigned on x86 but signed on ARM. So I made this pull request.