### PR TITLE
Detect FFmpeg version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ rand = "0.8"
 cpal = "0.13"
 env_logger = "^0.9"
 ringbuf = "0.2.3"
+
+[build-dependencies]
+ffmpeg-sys-next = "5.0.1"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,58 @@
+fn main() {
+  let avcodec_version_major = ffmpeg_sys_next::LIBAVCODEC_VERSION_MAJOR;
+  let avcodec_version_minor = ffmpeg_sys_next::LIBAVCODEC_VERSION_MINOR;
+  let avcodec_version_micro = ffmpeg_sys_next::LIBAVCODEC_VERSION_MICRO;
+
+  let ffmpeg_version = match avcodec_version_major {
+    57 => {
+      if avcodec_version_minor >= 107 {
+        Some("ffmpeg_3_4")
+      } else if avcodec_version_minor >= 89 {
+        Some("ffmpeg_3_3")
+      } else if avcodec_version_minor >= 64 {
+        Some("ffmpeg_3_2")
+      } else if avcodec_version_minor >= 48 {
+        Some("ffmpeg_3_1")
+      } else if avcodec_version_minor >= 24 {
+        Some("ffmpeg_3_0")
+      } else {
+        None
+      }
+    }
+    58 => {
+      if avcodec_version_minor >= 100 {
+        Some("ffmpeg_4_4")
+      } else if avcodec_version_minor >= 91 {
+        Some("ffmpeg_4_3")
+      } else if avcodec_version_minor >= 54 {
+        Some("ffmpeg_4_2")
+      } else if avcodec_version_minor >= 35 {
+        Some("ffmpeg_4_1")
+      } else if avcodec_version_minor >= 18 {
+        Some("ffmpeg_4_0")
+      } else {
+        None
+      }
+    }
+    59 => {
+      if avcodec_version_minor >= 37 {
+        Some("ffmpeg_5_1")
+      } else if avcodec_version_minor >= 18 {
+        Some("ffmpeg_5_0")
+      } else {
+        None
+      }
+    }
+    _ => None,
+  };
+
+  if let Some(ffmpeg_version) = ffmpeg_version {
+    // println!("cargo:warning={}", ffmpeg_version);
+    println!("cargo:rustc-cfg={}", ffmpeg_version);
+  } else {
+    panic!(
+      "Cannot define ffmpeg version from libavcodec version: {}.{}.{}",
+      avcodec_version_major, avcodec_version_minor, avcodec_version_micro
+    )
+  }
+}

--- a/build.rs
+++ b/build.rs
@@ -48,11 +48,10 @@ fn main() {
 
   if let Some(ffmpeg_version) = ffmpeg_version {
     // println!("cargo:warning={}", ffmpeg_version);
-    println!("cargo:rustc-cfg={}", ffmpeg_version);
+    println!("cargo:rustc-cfg={ffmpeg_version}");
   } else {
     panic!(
-      "Cannot define ffmpeg version from libavcodec version: {}.{}.{}",
-      avcodec_version_major, avcodec_version_minor, avcodec_version_micro
+      "Cannot define ffmpeg version from libavcodec version: {avcodec_version_major}.{avcodec_version_minor}.{avcodec_version_micro}"
     )
   }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -273,6 +273,7 @@ impl Stream {
     unsafe { (*(*self.stream).codecpar).channels }
   }
 
+  #[cfg(any(ffmpeg_4_4, ffmpeg_5_0, ffmpeg_5_1))]
   pub fn get_timecode(&self) -> Option<String> {
     unsafe {
       let timecode_side_data = av_stream_get_side_data(
@@ -287,6 +288,20 @@ impl Stream {
       }
       av_timecode_make_mpeg_tc_string(timecode, timecode_side_data as u32);
       Some(timecode.to_string())
+    }
+  }
+
+  #[cfg(any(ffmpeg_4_0, ffmpeg_4_1, ffmpeg_4_2, ffmpeg_4_3))]
+  pub fn get_timecode(&self) -> Option<String> {
+    unsafe {
+      let tc = &mut 0;
+      let timecode = (*(*self.stream).codec).timecode_frame_start;
+      if timecode < 0 {
+        return None;
+      }
+
+      av_timecode_make_mpeg_tc_string(tc, timecode as u32);
+      Some(tc.to_string())
     }
   }
 


### PR DESCRIPTION
Proposal for conditional compilation according to the available version of FFmpeg.

Tested on FFmpeg:
- v4.3.1
- v4.4.2
